### PR TITLE
Add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,404 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), but uses the custom versioning scheme `MAJOR.MINOR`:
+
+- `MAJOR` denotes the switch from test to production phase for `0 -> 1` and fundamental codebase rewrites afterwards.
+- `MINOR` indicates the index of releasable features and patches made.
+
+
+
+## 0.31 - 2024-12-16
+
+### Added
+
+- Add logo to project `README.md`
+- Add licensing information to both project and logo `README.md`
+- Add instructions to view RDF metadata
+- Add metadata to logo and breakdown SVG files
+- Add dependencies to logo-generating script
+- Add logo, breakdown, generating Python script and `README.md`
+
+
+
+## 0.30 - 2024-11-15
+
+### Added
+
+- Add `StatusBar` widgets and actions
+
+### Changed
+
+- Adapt config parameter names
+
+
+
+## 0.29 - 2024-11-15
+
+### Added
+
+- Add `disconnected` event to `WebsocketConnection`
+- Add `FeatureStatus` widget
+- Add `ComponentStatus` widget
+
+### Changed
+
+- Let `Component` logging level inherit from parent logger
+- Set default logging level to `INFO` in the `click` interface
+- Move basic authentication handling to `WebsocketConnection`
+
+
+
+## 0.28 - 2024-11-12
+
+### Added
+
+- Add `Status` widgets
+- Add `ConfigInput` widget
+- Add `QRCodeView` widget
+- Add `ConfigPanel` widget
+- Add `ConfigView` widget
+- Add `StatusBar` widget
+
+### Changed
+
+- Move config widgets into its own module
+- Store UI components in a separate subpackage
+- Manage components with Worker API
+- Redesign `MessageView` and colors in chat app
+
+
+
+## 0.27 - 2024-09-26
+
+### Changed
+
+- Bump `websockets` version to 13.1
+
+
+
+## 0.26 - 2024-09-26
+
+### Fixed
+
+- Fix unstable `TextRenderer` component
+
+
+
+## 0.25 - 2024-09-25
+
+### Fixed
+
+- Fix language not set if `YTextArea` in chat app
+
+
+
+## 0.24 - 2024-09-25
+
+### Added
+
+- Add `YDocument` class
+- Add `YEdit` class
+
+### Changed
+
+- Rewrite `YTextArea`
+- Make `YDocument` syntax-aware
+- Adjust editor app and chat app for new `YTextArea`
+
+
+
+## 0.23 - 2024-09-13
+
+### Added
+
+- Add `--user` and display `--name` options to CLI
+- Add `click` callback to log order of processed `click.Parameters`
+- Add basic authentication handling to service
+- Add `ErrorScreen`
+- Add `CredentialScreen` to chat app
+
+### Changed
+
+- Fall back to `Yjs` protocol if none is given
+- Rework gathering context information
+- Rename `--message-type` to `--messages`
+- Move `LOGGER_NAME` context variable into `log` module
+- Put `LOGGER_NAME` in the `click` command so that it does not get set on imports
+
+### Fixed
+
+- Fix minor UI issues
+- Fix abort on missing username
+
+
+
+## 0.22 - 2024-09-06
+
+### Changed
+
+- Update `MANIFEST.in` to also include TCSS files
+- Use `src` layout for `setuptools`'s automatic discovery and no-config build
+- Replace and modify `Dockerfile` to enable CLI usage
+- Split `server` module in library and app modules
+
+
+
+## 0.21 - 2024-09-06
+
+### Added
+
+- Add `LDAPBasicAuth` to server
+- Add `CredentialScreen` to editor app
+
+### Changed
+
+- Make LDAP basic authentication accessible via CLI
+- Move LDAPBasicAuth into the `auth` module
+
+
+
+## 0.20 - 2024-09-04
+
+### Added
+
+- Add basic example for Textual authentication client
+
+### Changed
+
+- Change to `websockets` development dependency
+- Rework `WebsocketConnection`
+
+
+
+## 0.19 - 2024-08-30
+
+### Added
+
+- Add `BasicAuth` class for use in `websockets.serve`
+- Add examples 
+- Add LDAP self-bind function
+
+### Fixed
+
+- Fix inconsistent class naming
+
+
+
+## 0.18 - 2024-08-30
+
+### Changed
+
+- Change to `PDM` python package manager
+
+
+
+## 0.17 - 2024-08-30
+
+### Changed
+
+- Ignore private ELVA config file
+- Use `ContextVar` to set the logger name accordingly
+
+
+
+## 0.16 - 2024-08-30
+
+### Added
+
+- Implement ability to gather context information
+
+### Changed
+
+- Store identifier in file
+- Update data and log paths
+
+
+
+## 0.15 - 2024-08-27
+
+### Added
+
+- Add cross-sync tests
+- Add cross-sync for `service` and `server`
+
+### Changed
+
+- Rename `message_encoding` to `message_type`
+- Rewrite provider for Yjs and ELVA protocol 
+- Proper naming of helper function plus comments
+
+### Fixed
+
+- Fix parser tests with delays
+
+### Removed
+
+- Remove test files
+
+
+
+## 0.14 - 2024-08-19
+
+### Added
+
+- Add logging capabilities to `service`
+- Add `ElvaWebsocketServer`
+
+### Changed
+
+- Rewrite `server` module
+- Make `Component` actually wait for `before` coroutine to complete 
+- change `SQLiteStore` logging
+- Changes in persistence, CLI, style
+- Sort `service` and `server` to `apps` subpackage
+- Apply `ruff` formatting on provider module
+- Rewrite `service` with `WebsocketConnection` component
+
+### Removed
+
+- Remove unused utils
+
+
+
+## 0.13 - 2024-07-08
+
+### Added
+
+- Add `WebsocketHandler` logging handler
+
+
+
+## 0.12 - 2024-07-05
+
+### Fixed
+
+- Test ruff formatting/fixing
+
+
+
+## 0.11 - 2024-07-04
+
+### Changed
+
+- Replace logging `dictConfig` with custom classes and logging server
+
+### Fixed
+
+- Fix missing base class for `DefaultFormatter`
+
+
+
+## 0.10 - 2024-07-04
+
+### Changed
+
+- Write `click` decorators consistently
+- Define default paths and adapt `click` commands
+
+
+
+## 0.9 - 2024-07-02
+
+### Changed
+
+- Make `Provider` choice independent of local or remote
+
+
+
+## 0.8 - 2024-07-02
+
+### Removed
+
+- Remove `log` server module
+
+
+
+## 0.7 - 2024-07-02
+
+### Fixed
+
+- Fix `pycrdt` imports on `metaprovider`
+
+
+
+## 0.6 - 2024-07-02
+
+### Changed
+
+- Try logging to TCP socket
+
+
+
+## 0.5 - 2024-07-02
+
+### Changed
+
+- Rename package-logging module
+
+
+
+## 0.4 - 2024-07-02
+
+### Changed
+
+- Change to static version
+- Bump `pycrdt` libraries
+
+### Removed
+
+- Remove `setuptools-scm` dependency and `_version.py`
+
+
+
+## 0.3 - 2024-07-02
+
+### Added
+
+- Add emoji test
+
+### Changed
+
+- Make indices of `YText` being based on UTF-8 encoding
+
+### Fixed
+
+- Fix disappearing messages behind the tabview in chat app
+
+
+
+## 0.2 - 2024-07-02
+
+### Changed
+
+- Switch to file logging on object and module level
+
+
+
+## 0.1 - 2024-06-25
+
+### Added
+
+- Add `metaprovider`
+- Add `YMessage` codecs
+- Add `SQLiteStore` component 
+- Add `TextRenderer` component
+- Add generic `Component` class
+- Add logging config
+- Add test for parser self instantiation
+- Add parser classes `TextParser`, `ArrayParser` and `MapParser`
+- Add editor app
+- Add chat app
+- Add file management (read and write)
+- Add `lazy_app_cli` decorator for apps
+- Add command line interface (CLI) along lazy loading
+- Add `Provider` class
+- Add `Connection` class
+- Add `.gitignore`
+- Add `MkDocs` as documentation framework
+- Add proper project configuration
+- Add proper README.md
+- Add project information
+- Add Python requirements
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 
 
+## 0.32 - 2025-02-13
+
+### Added
+
+- Add `CHANGELOG.md` up to version v0.31
+- Add `git-cliff` along side config
+
+### Changed
+
+- Change fill color from `transparent` to `none`
+
+### Fixed
+
+- Fix logo `mask` element not being in definitions
+
+
+
 ## 0.31 - 2024-12-16
 
 ### Added

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,61 @@
+# git-cliff ~ configuration file
+# https://git-cliff.org/docs/configuration
+#
+# templates are written for Tera
+# https://keats.github.io/tera/
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), but uses the custom versioning scheme `MAJOR.MINOR`:
+
+- `MAJOR` denotes the switch from test to production phase for `0 -> 1` and fundamental codebase rewrites afterwards.
+- `MINOR` indicates the index of releasable features and patches made.\n
+"""
+
+body = """\n
+{% if version -%}
+    ## {{ version | trim_start_matches(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+    ## [Unreleased]
+{% endif -%}
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {{ commit.message | split(pat="\n") | first | upper_first | trim }}\
+    {% endfor %}
+{% endfor %}\n
+"""
+
+# remove the leading and trailing whitespace from the templates
+trim = true
+
+[git]
+tag_pattern = "v[0-9].[0-9]+"
+# parse the commits based on https://www.conventionalcommits.org
+conventional_commits = false
+# filter out the commits that are not conventional
+filter_unconventional = false
+# regex for parsing and grouping commits
+commit_parsers = [
+    { message = "^[a|A]dd", group = "Added" },
+    { message = "^[s|S]upport", group = "Added" },
+    { message = "^[r|R]emove", group = "Removed" },
+    { message = "^.*: add", group = "Added" },
+    { message = "^.*: support", group = "Added" },
+    { message = "^.*: remove", group = "Removed" },
+    { message = "^.*: delete", group = "Removed" },
+    { message = "^[t|T]est", group = "Fixed" },
+    { message = "^[f|F]ix", group = "Fixed" },
+    { message = "^.*: fix", group = "Fixed" },
+    { message = "^.*", group = "Changed" },
+]
+# filter out the commits that are not matched by commit parsers
+filter_commits = false
+# sort the tags topologically
+topo_order = false
+# sort the commits inside sections by oldest/newest order
+sort_commits = "newest"

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "logo"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:94d83b5e968b929458c4074362c8e61f7d4e811c989e4651d37b2f1bfcef79dc"
+content_hash = "sha256:c3213af580c9c6058e183a3852cdedbf69ba1eef9a39f208245a649287ca2bb9"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -526,6 +526,25 @@ dependencies = [
 files = [
     {file = "ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343"},
     {file = "ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619"},
+]
+
+[[package]]
+name = "git-cliff"
+version = "2.7.0"
+requires_python = ">=3.7"
+summary = "A highly customizable changelog generator ⛰️"
+groups = ["dev"]
+files = [
+    {file = "git_cliff-2.7.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:84de0ab5e213c64f59c0f5e1a8285c578ed5a28667bdab31ebc2f7db764fc32e"},
+    {file = "git_cliff-2.7.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:45dcda6206f8b2b7ec0de56b9ee3a7ff12253e59737290a5a918ed8eb62adfe2"},
+    {file = "git_cliff-2.7.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f8b0cb192ab12f3b23b113e6f190c8b060a03f306e447a60580d1e0563f0d3e"},
+    {file = "git_cliff-2.7.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e65f9ee3f747c57356a7efee156fcd2b6d01428dba61c4cd1f0e773d8c842ca6"},
+    {file = "git_cliff-2.7.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:7b2f5dbb82e1d8b62c6885d06eda8a11daa063e6f124b16db634f5e23371ac49"},
+    {file = "git_cliff-2.7.0-py3-none-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1bdf9c04a883a70cdb0b29bf033ea39d64fab6ba28459b332cd221a7f47d86f0"},
+    {file = "git_cliff-2.7.0-py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a698f9b8b10e6df0dd47b049b75c25f8cfb3dc4f973ab05790912ba55e5a4ebb"},
+    {file = "git_cliff-2.7.0-py3-none-win32.whl", hash = "sha256:914015dd0deab69f23718a8ee982018140095b5b1f45268b15abdfd99d60e098"},
+    {file = "git_cliff-2.7.0-py3-none-win_amd64.whl", hash = "sha256:7180874591548846cf30e4cb6953ff74e8ed2d4bed4487c5e39122581bef15c7"},
+    {file = "git_cliff-2.7.0.tar.gz", hash = "sha256:15badec95cc5c9c7755dc5a0775cc8c836f5c5f271f20ed6a4f32af093ec1eaa"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools", "setuptools-scm", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -51,7 +51,7 @@ dependencies = [
     "tomli-w>=1.1.0",
     "tomli>=1.1.0",
 ]
-version = "0.0.1"
+dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = [
@@ -66,6 +66,7 @@ dev = [
     "mkdocs>=1.6.1",
     "mkdocstrings>=0.25.2",
     "textual-dev>=1.5.1",
+    "git-cliff>=2.7.0",
 ]
 
 # TODO complete url list
@@ -87,3 +88,5 @@ elva = "elva.cli:elva"
 
 [tool.pdm]
 distribution = true
+
+[tool.setuptools_scm]


### PR DESCRIPTION
With this PR, a changelog is added via `git-cliff`. Also, the versioning of the `elva` package is now based on git tags via `setuptools-scm`.